### PR TITLE
Fix NullPointerException when parent directory doesn't exists

### DIFF
--- a/src/test/java/org/embulk/output/ftp/TestFtpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/ftp/TestFtpFileOutputPlugin.java
@@ -117,6 +117,7 @@ public class TestFtpFileOutputPlugin
         assertEquals(false, task.getSsl());
         assertEquals(true, task.getSslExplicit());
         assertEquals(10, task.getMaxConnectionRetry());
+        assertEquals("/", task.getDirectorySeparator());
     }
 
     @Test


### PR DESCRIPTION
When parent directory doesn't exists at remote server, plugin throws NullPointerException.
e.g. `path_prefix: test`

``` sh
2016-09-05 11:13:21.105 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
java.lang.NullPointerException
org.embulk.exec.PartialExecutionException: java.lang.NullPointerException
    at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:363)
    at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:572)
    at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
    at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:374)
    at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:370)
    at org.embulk.spi.Exec.doWith(Exec.java:25)
    at org.embulk.exec.BulkLoader.run(BulkLoader.java:370)
    at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
    at com.treasuredata.worker.calls.EmbulkResult.run(EmbulkResult.java:62)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at com.treasuredata.java_call.JavaCall.processRequest(JavaCall.java:147)
    at com.treasuredata.java_call.JavaCall.run(JavaCall.java:111)
    at com.treasuredata.worker.JavaCallMain.main(JavaCallMain.java:21)
Caused by: java.lang.NullPointerException
    at org.embulk.output.ftp.FtpFileOutputPlugin$FtpFileOutput.getRemoteDirectory(FtpFileOutputPlugin.java:314)
    at org.embulk.output.ftp.FtpFileOutputPlugin$FtpFileOutput.nextFile(FtpFileOutputPlugin.java:181)
    at org.embulk.spi.util.FileOutputOutputStream.nextFile(FileOutputOutputStream.java:34)
    at org.embulk.spi.util.LineEncoder.nextFile(LineEncoder.java:93)
    at org.embulk.standards.CsvFormatterPlugin.open(CsvFormatterPlugin.java:116)
    at org.embulk.spi.FileOutputRunner.open(FileOutputRunner.java:140)
    at org.embulk.spi.util.Executors.process(Executors.java:56)
    at org.embulk.spi.util.Executors.process(Executors.java:42)
    at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184)
    at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```
