### PR TITLE
Only build for Java8 and fix Travis CI Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 
 script:
   - ./gradlew gem

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ configurations {
 
 version = "0.1.7"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compile  "org.embulk:embulk-core:0.8.9"


### PR DESCRIPTION
Same with https://github.com/embulk/embulk-input-gcs/pull/35

Recently I got build failure only with Java7 at Travis CI. Build succeded with Java8.
https://travis-ci.org/embulk/embulk-output-ftp/builds/398109695

Travis stopped to support Java7 and it's time to remove it from .travis.yml

Additionally, We're going to support Java8 with Embulk and its plugins. I updated build.gradle.