### PR TITLE
Fix unclosed resource to prevent temp file deletion failure on Windows

### DIFF
--- a/src/main/java/org/embulk/output/ftp/FtpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/ftp/FtpFileOutputPlugin.java
@@ -261,10 +261,11 @@ public class FtpFileOutputPlugin implements FileOutputPlugin
                                             }
                                         }
                                     }
-                                    client.upload(filePath,
-                                            new BufferedInputStream(new FileInputStream(file)), 0L, 0L,
-                                            new LoggingTransferListener(file.getAbsolutePath(), filePath, log, TRANSFER_NOTICE_BYTES)
-                                    );
+                                    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
+                                        client.upload(filePath, in, 0L, 0L,
+                                                new LoggingTransferListener(file.getAbsolutePath(), filePath, log, TRANSFER_NOTICE_BYTES)
+                                        );
+                                    }
                                     if (!file.delete()) {
                                         throw new ConfigException("Couldn't delete local file " + file.getAbsolutePath());
                                     }


### PR DESCRIPTION
This PR fixes a bug that temp file deletion fails on Windows.
This bug was reported by OSS guy.
https://translate.google.com/translate?hl=ja&sl=auto&tl=en&u=https%3A%2F%2Fteratail.com%2Fquestions%2F200148

```
org.embulk.exec.PartialExecutionException: org.embulk.config.ConfigException: Co
uldn't delete local file C:\Users\ADMINI~1\AppData\Local\Temp\2\embulk\2019-07-1
2 06-16-09.234 UTC\test000.00.csv3105253771120283850.tmp
        at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(B
ulkLoader.java:340)
        at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
        at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
        at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
        at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
        at org.embulk.spi.Exec.doWith(Exec.java:22)
        at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
        at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:178)
        at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:292)
        at org.embulk.EmbulkRunner.run(EmbulkRunner.java:156)
        at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:433)
        at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
        at org.embulk.cli.Main.main(Main.java:64)
Caused by: org.embulk.config.ConfigException: Couldn't delete local file C:\User
s\ADMINI~1\AppData\Local\Temp\2\embulk\2019-07-12 06-16-09.234 UTC\test000.00.cs
v3105253771120283850.tmp
        at org.embulk.output.ftp.FtpFileOutputPlugin$FtpFileOutput$1.call(FtpFil
eOutputPlugin.java:269)
        at org.embulk.output.ftp.FtpFileOutputPlugin$FtpFileOutput$1.call(FtpFil
eOutputPlugin.java:245)
        at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:81)
        at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java
:62)
        at org.embulk.output.ftp.FtpFileOutputPlugin$FtpFileOutput.uploadFile(Ft
pFileOutputPlugin.java:245)
        at org.embulk.output.ftp.FtpFileOutputPlugin$FtpFileOutput.finish(FtpFil
eOutputPlugin.java:233)
        at org.embulk.spi.util.FileOutputOutputStream.close(FileOutputOutputStre
am.java:94)
        at sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:320)
        at sun.nio.cs.StreamEncoder.close(StreamEncoder.java:149)
        at java.io.OutputStreamWriter.close(OutputStreamWriter.java:233)
        at java.io.BufferedWriter.close(BufferedWriter.java:266)
        at org.embulk.spi.util.LineEncoder.finish(LineEncoder.java:90)
        at org.embulk.standards.CsvFormatterPlugin$1.finish(CsvFormatterPlugin.j
ava:194)
        at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.finis
h(FileOutputRunner.java:154)
        at org.embulk.spi.PageBuilder.finish(PageBuilder.java:228)
        at org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:377)
        at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:140)
        at org.embulk.spi.util.Executors.process(Executors.java:62)
        at org.embulk.spi.util.Executors.process(Executors.java:38)
        at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecut
orPlugin.java:170)
        at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecut
orPlugin.java:167)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.
java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor
.java:624)
        at java.lang.Thread.run(Thread.java:748)
        Suppressed: org.embulk.config.ConfigException: Couldn't delete local fil
e C:\Users\ADMINI~1\AppData\Local\Temp\2\embulk\2019-07-12 06-16-09.234 UTC\test
001.00.csv6718041067910710146.tmp
                ... 25 more
        Suppressed: org.embulk.config.ConfigException: Couldn't delete local fil
e C:\Users\ADMINI~1\AppData\Local\Temp\2\embulk\2019-07-12 06-16-09.234 UTC\test
002.00.csv9129426862521090912.tmp
                ... 25 more

Error: org.embulk.config.ConfigException: Couldn't delete local file C:\Users\AD
MINI~1\AppData\Local\Temp\2\embulk\2019-07-12 06-16-09.234 UTC\test000.00.csv310
5253771120283850.tmp
```

The cause is probably same with https://github.com/embulk/embulk-output-azure_blob_storage/pull/14
If resource isn't closed, Java program fails to delete temp file.

I don't have an Windows env. I'll ask certain guy to check after release.