### PR TITLE
Do not use prefix in createTempFile, and release 0.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 services:
   - docker
 before_script:

--- a/build.gradle
+++ b/build.gradle
@@ -17,20 +17,20 @@ configurations {
     provided
 }
 
-version = "0.2.2"
+version = "0.2.3"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.9.11"
-    provided "org.embulk:embulk-core:0.9.11"
+    compile  "org.embulk:embulk-core:0.9.20"
+    provided "org.embulk:embulk-core:0.9.20"
     compile files("libs/ftp4j-1.7.2.jar")
     compile 'org.embulk.input.ftp:embulk-util-ftp:0.1.6'
     compile "org.bouncycastle:bcpkix-jdk15on:1.52"
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.9.11:tests"
-    testCompile "org.embulk:embulk-standards:0.9.11"
+    testCompile "org.embulk:embulk-core:0.9.20:tests"
+    testCompile "org.embulk:embulk-standards:0.9.20"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/src/main/java/org/embulk/output/ftp/FtpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/ftp/FtpFileOutputPlugin.java
@@ -190,7 +190,7 @@ public class FtpFileOutputPlugin implements FileOutputPlugin
                     filePath = separator + filePath;
                 }
                 remoteDirectory = getRemoteDirectory(filePath, separator);
-                file = Exec.getTempFileSpace().createTempFile(filePath, "tmp");
+                file = Exec.getTempFileSpace().createTempFile("tmp");
                 log.info("Writing local temporary file \"{}\"", file.getAbsolutePath());
                 output = new BufferedOutputStream(new FileOutputStream(file));
             }


### PR DESCRIPTION
Embulk v0.9.20 started to use java.nio.file.Files.createTempFile,
instead of java.io.File.createTempFile, to create a temp file.

But, these two APIs had a difference when "/" is included in prefix.

`File.createTempFile("fooA/barA", ".tmp", new File("/tmp"));`
==> Creates /tmp/barA9003569178568216717.tmp

`Files.createTempFile(Paths.get("/tmp"), "fooB/barB", ".tmp");`
==> Throws IllegalArgumentException

The prefix is not required to create a temp file in this plugin,
actually. Just removing the prefix is the simplest fix for this.